### PR TITLE
fix: ThemeChanger will be shown in mobile view

### DIFF
--- a/src/components/DarkSwitch.tsx
+++ b/src/components/DarkSwitch.tsx
@@ -12,11 +12,11 @@ const ThemeChanger = () => {
   if (!mounted) return null;
 
   return (
-    <div className="flex items-center">
+    <div className="flex items-center order-last ">
       {theme === "dark" ? (
         <button
           onClick={() => setTheme("light")}
-          className="text-gray-300 rounded-full outline-none focus:outline-none">
+          className="text-gray-300 rounded-full outline-none focus:outline-none ">
           <span className="sr-only">Light Mode</span>
 
           <svg

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,30 +15,39 @@ export const Navbar = () => {
 
   return (
     <div className="w-full">
-      <nav className="container relative flex flex-wrap items-center justify-between p-8 mx-auto lg:justify-between xl:px-0">
+      <nav className="container relative flex flex-wrap items-center justify-between p-8 mx-auto lg:justify-between xl:px-1">
         {/* Logo  */}
+        <Link href="/">
+          <span className="flex items-center space-x-2 text-2xl font-medium text-indigo-500 dark:text-gray-100">
+              <span>
+                <Image
+                  src="/img/logo.svg"
+                  width="32"
+                  alt="N"
+                  height="32"
+                  className="w-8"
+                />
+              </span>
+            <span>Nextly</span>
+          </span>
+        </Link>
+
+        {/* get started  */}
+        <div className="gap-3 nav__item mr-2 lg:flex ml-auto lg:ml-0 lg:order-2">
+            <ThemeChanger />
+            <div className="hidden mr-3 lg:flex nav__item">
+              <Link href="/" className="px-6 py-2 text-white bg-indigo-600 rounded-md md:ml-5">
+                Get Started
+              </Link>
+            </div>
+        </div>
+                
         <Disclosure>
           {({ open }) => (
             <>
-              <div className="flex flex-wrap items-center justify-between w-full lg:w-auto">
-                <Link href="/">
-                  <span className="flex items-center space-x-2 text-2xl font-medium text-indigo-500 dark:text-gray-100">
-                    <span>
-                      <Image
-                        src="/img/logo.svg"
-                        alt="N"
-                        width="32"
-                        height="32"
-                        className="w-8"
-                      />
-                    </span>
-                    <span>Nextly</span>
-                  </span>
-                </Link>
-
                 <Disclosure.Button
                   aria-label="Toggle Menu"
-                  className="px-2 py-1 ml-auto text-gray-500 rounded-md lg:hidden hover:text-indigo-500 focus:text-indigo-500 focus:bg-indigo-100 focus:outline-none dark:text-gray-300 dark:focus:bg-trueGray-700">
+                  className="px-2 py-1 text-gray-500 rounded-md lg:hidden hover:text-indigo-500 focus:text-indigo-500 focus:bg-indigo-100 focus:outline-none dark:text-gray-300 dark:focus:bg-trueGray-700">
                   <svg
                     className="w-6 h-6 fill-current"
                     xmlns="http://www.w3.org/2000/svg"
@@ -71,11 +80,10 @@ export const Navbar = () => {
                     </Link>
                   </>
                 </Disclosure.Panel>
-              </div>
             </>
           )}
         </Disclosure>
-
+        
         {/* menu  */}
         <div className="hidden text-center lg:flex lg:items-center">
           <ul className="items-center justify-end flex-1 pt-6 list-none lg:pt-0 lg:flex">
@@ -89,13 +97,6 @@ export const Navbar = () => {
           </ul>
         </div>
 
-        <div className="hidden mr-3 space-x-4 lg:flex nav__item">
-          <Link href="/" className="px-6 py-2 text-white bg-indigo-600 rounded-md md:ml-5">
-              Get Started
-          </Link>
-
-          <ThemeChanger />
-        </div>
       </nav>
     </div>
   );


### PR DESCRIPTION
Updated the navbar to display the ThemeChanger in mobile view. The ThemeChanger now appears just before the menu bars, enabling users to switch to light mode while on mobile.

![Screen Shot 2024-08-28 at 01 28 03](https://github.com/user-attachments/assets/b483fb8a-3af0-483d-b684-7bf659797c27)
